### PR TITLE
Remove default parameter

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -103,7 +103,7 @@ def main(named_area):
 
 if __name__ == "__main__":
     start = timeit.default_timer()
-    main("")
+    main()
     stop = timeit.default_timer()
     exe_time = stop - start
     print(f"Program Executed in {str(exe_time)}")


### PR DESCRIPTION
When a default parameter is passed to main, then you can no longer pass the area name on the command-line (it always prompts).

On Ubuntu, removing the empty string allows parameter to be passed from the command-line and the interactive prompt still works if it is not provided.